### PR TITLE
mpwt 0.5.9

### DIFF
--- a/mpwt/__init__.py
+++ b/mpwt/__init__.py
@@ -3,4 +3,4 @@ from mpwt.mpwt_workflow import multiprocess_pwt
 from mpwt.utils import cleaning, cleaning_input, find_ptools_path, list_pgdb, pubmed_citations, remove_pgdbs
 from mpwt.to_pathologic import create_pathologic_file
 
-__version__='0.5.8'
+__version__='0.5.9'

--- a/mpwt/mpwt_workflow.py
+++ b/mpwt/mpwt_workflow.py
@@ -61,7 +61,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
     # Check if Pathway Tools is in the path.
     # Find PGDB folder path.
     ptools_local_path = utils.find_ptools_path()
-    pgdbs_folder_path = ptools_local_path + '/pgdbs/user/'
+    pgdbs_folder_path = os.path.join(*[ptools_local_path, 'pgdbs', 'user'])
 
     # Check if ptools-local is accessible.
     error = utils.check_ptools_local_pwt()
@@ -124,7 +124,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
 
     # Create taxon file in the input folder.
     if taxon_file and input_folder and not patho_inference:
-        taxon_file_pathname = input_folder + '/taxon_id.tsv'
+        taxon_file_pathname = os.path.join(input_folder, 'taxon_id.tsv')
         if os.path.exists(taxon_file_pathname):
             sys.exit('taxon ID file (' + taxon_file_pathname + ') already exists.')
         else:
@@ -156,8 +156,8 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
             multiprocess_run_pwt_dats = []
             multiprocess_run_move_pgdbs = []
             for run_patho_dat_id in run_patho_dat_ids:
-                input_folder_path = input_folder + '/' + run_patho_dat_id + '/'
-                species_pgdb_folder = pgdbs_folder_path + run_patho_dat_id.lower() + 'cyc/'
+                input_folder_path = os.path.join(input_folder, run_patho_dat_id)
+                species_pgdb_folder = os.path.join(pgdbs_folder_path, run_patho_dat_id.lower() + 'cyc')
                 input_run_move_pgdbs = [run_patho_dat_id, species_pgdb_folder]
                 input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction])
                 multiprocess_pwt_input_files.append([input_folder_path, taxon_file])
@@ -205,7 +205,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
     if (dat_creation and not input_folder) or (output_folder and not input_folder):
         only_dat_creation = True
         # Create a temporary folder in ptools-local where list script will be stored.
-        tmp_folder = ptools_local_path + '/tmp/'
+        tmp_folder = os.path.join(ptools_local_path, 'tmp')
         if not os.path.exists(tmp_folder):
             os.mkdir(tmp_folder)
 
@@ -214,8 +214,8 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
         multiprocess_run_pwt_dats = []
         multiprocess_run_move_pgdbs = []
         for dat_run_id in dat_run_ids:
-            input_folder_path = input_folder + '/' + dat_run_id + '/'
-            species_pgdb_folder = pgdbs_folder_path + dat_run_id.lower() + 'cyc/'
+            input_folder_path = os.path.join(input_folder, dat_run_id)
+            species_pgdb_folder = os.path.join(pgdbs_folder_path, dat_run_id.lower() + 'cyc')
             input_run_move_pgdbs = [dat_run_id, species_pgdb_folder]
             if only_dat_creation:
                 input_run_move_pgdbs = retrieve_complete_id(input_run_move_pgdbs)
@@ -241,9 +241,10 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
             run_dat_ids = tmp_run_dat_ids
         if run_dat_ids:
             for run_dat_id in run_dat_ids:
-                create_dat_creation_script(run_dat_id, input_folder + "/" + run_dat_id + "/" + "dat_creation.lisp")
-                input_folder_path = input_folder + '/' + run_dat_id + '/'
-                species_pgdb_folder = pgdbs_folder_path + run_dat_id.lower() + 'cyc/'
+                dat_creation_path = os.path.join(*[input_folder, run_dat_id, 'dat_creation.lisp'])
+                create_dat_creation_script(run_dat_id, dat_creation_path)
+                input_folder_path = os.path.join(input_folder, run_dat_id)
+                species_pgdb_folder = os.path.join(pgdbs_folder_path, run_dat_id.lower() + 'cyc')
                 multiprocess_run_pwt_dats.append([input_folder_path])
                 input_run_move_pgdbs = [run_dat_id, species_pgdb_folder]
                 input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction])
@@ -280,7 +281,8 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
 
     if (dat_creation and not input_folder) or (output_folder and not input_folder):
         ptools_local_path = utils.find_ptools_path()
-        shutil.rmtree(ptools_local_path + '/tmp')
+        ptools_local_tmp_path = os.path.join(ptools_local_path, 'tmp')
+        shutil.rmtree(ptools_local_tmp_path)
 
     logger.info('~~~~~~~~~~End of Pathway Tools~~~~~~~~~~')
 
@@ -310,7 +312,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
             if not os.path.exists(patho_log):
                 logger.info('No log directory, it will be created.')
                 os.mkdir(patho_log)
-        patho_error_pathname = patho_log + '/log_error.txt'
+        patho_error_pathname = os.path.join(patho_log, 'log_error.txt')
         with open(patho_error_pathname, 'a') as input_file:
             input_file.write('\n\n---------Time---------\n')
             for index, step_time in enumerate(times):

--- a/mpwt/mpwt_workflow.py
+++ b/mpwt/mpwt_workflow.py
@@ -214,13 +214,13 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
         multiprocess_run_pwt_dats = []
         multiprocess_run_move_pgdbs = []
         for dat_run_id in dat_run_ids:
-            input_folder_path = os.path.join(input_folder, dat_run_id)
+            input_tmp_folder_path = os.path.join(tmp_folder, dat_run_id)
             species_pgdb_folder = os.path.join(pgdbs_folder_path, dat_run_id.lower() + 'cyc')
             input_run_move_pgdbs = [dat_run_id, species_pgdb_folder]
             if only_dat_creation:
                 input_run_move_pgdbs = retrieve_complete_id(input_run_move_pgdbs)
             input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction])
-            multiprocess_run_pwt_dats.append([input_folder_path])
+            multiprocess_run_pwt_dats.append([input_tmp_folder_path])
             multiprocess_run_move_pgdbs.append(input_run_move_pgdbs)
 
     # Add species that have data in PGDB but are not present in output folder.

--- a/mpwt/pathologic_input.py
+++ b/mpwt/pathologic_input.py
@@ -673,7 +673,8 @@ def create_only_dat_lisp(pgdbs_folder_path, tmp_folder):
         generator: generator with the PGDB IDs.
     """
     for species_pgdb in os.listdir(pgdbs_folder_path):
-        if os.path.isdir(pgdbs_folder_path + species_pgdb):
+        species_dir_path = os.path.join(pgdbs_folder_path, species_pgdb)
+        if os.path.isdir(species_dir_path):
             pgdb_id = species_pgdb[:-3]
             pgdb_pathname = os.path.join(tmp_folder, pgdb_id)
             tmp_pgdb_path = os.path.join(tmp_folder, pgdb_id)

--- a/mpwt/pwt_wrapper.py
+++ b/mpwt/pwt_wrapper.py
@@ -32,7 +32,7 @@ def pwt_check_error(species_input_folder_path, subprocess_stdout, cmd, error_sta
     """
     if error_status:
         logger.critical('!!!!!!!!!!!!!!!!!----------------------------------------!!!!!!!!!!!!!!!!!')
-    species_name = species_input_folder_path.split('/')[-2]
+    species_name = os.path.basename(species_input_folder_path)
     if subprocess_returncode:
         logger.critical('Error for {0} with PathoLogic subprocess, return code: {1}'.format(species_name, str(subprocess_returncode)))
     if subprocess_stderr:
@@ -76,7 +76,7 @@ def check_log(species_input_folder_path, log_filename, error_status, log_errors)
         boolean: True if there is an error during Pathway Tools run
     """
     fatal_error_index = None
-    log_file_path = species_input_folder_path + '/' + log_filename
+    log_file_path = os.path.join(species_input_folder_path, log_filename)
     with open(log_file_path, 'r') as log_file:
         for index, line in enumerate(log_file):
             if line != '':
@@ -130,7 +130,7 @@ def run_pwt(species_input_folder_path, patho_hole_filler, patho_operon_predictor
     patho_lines = []
 
     # Name of the file containing the log from Pathway Tools terminal.
-    pwt_log = species_input_folder_path + 'pwt_terminal.log'
+    pwt_log = os.path.join(species_input_folder_path, 'pwt_terminal.log')
 
     try:
         # Launch Pathway Tools PathoLogic.
@@ -188,7 +188,7 @@ def run_pwt_dat(species_input_folder_path):
     Returns:
         boolean: True if there is an error during lisp script execution
     """
-    lisp_path = species_input_folder_path + 'dat_creation.lisp'
+    lisp_path = os.path.join(species_input_folder_path, 'dat_creation.lisp')
     cmd_options = ['-no-patch-download', '-disable-metadata-saving', '-nologfile']
     cmd_dat = ['pathway-tools', *cmd_options, '-load', lisp_path]
 
@@ -200,7 +200,7 @@ def run_pwt_dat(species_input_folder_path):
     load_lines = []
 
     # Name of the file containing the log from Pathway Tools terminal.
-    dat_log = species_input_folder_path + 'dat_creation.log'
+    dat_log = os.path.join(species_input_folder_path, 'dat_creation.log')
 
     try:
         # Launch Pathway Tools lisp command.
@@ -258,10 +258,10 @@ def run_move_pgdb(pgdb_folder_dbname, pgdb_folder_path, dat_extraction, output_f
         output_folder (str): path to output folder
         size_reduction (bool): to compress or not the results
     """
-    output_species = output_folder + '/' + pgdb_folder_dbname +'/'
+    output_species = os.path.join(output_folder, pgdb_folder_dbname)
 
     if dat_extraction:
-        pgdb_tmp_folder_path = pgdb_folder_path + '/1.0/data'
+        pgdb_tmp_folder_path = os.path.join(*[pgdb_folder_path, '1.0', 'data'])
     else:
         pgdb_tmp_folder_path = pgdb_folder_path
 
@@ -270,21 +270,23 @@ def run_move_pgdb(pgdb_folder_dbname, pgdb_folder_path, dat_extraction, output_f
     if size_reduction:
         if dat_extraction:
             for pgdb_file in os.listdir(pgdb_tmp_folder_path):
-                pgdb_file_pathname = pgdb_tmp_folder_path + '/' + pgdb_file
+                pgdb_file_pathname = os.path.join(pgdb_tmp_folder_path, pgdb_file)
                 if '.dat' not in pgdb_file:
                     if os.path.isfile(pgdb_file):
                         os.remove(pgdb_file_pathname)
                     elif os.path.isdir(pgdb_file):
                         shutil.rmtree(pgdb_file_pathname)
-        shutil.make_archive(output_folder + '/' + pgdb_folder_dbname, 'zip', pgdb_tmp_folder_path)
+        zip_input_path = os.path.join(output_folder, pgdb_folder_dbname)
+        shutil.make_archive(zip_input_path, 'zip', pgdb_tmp_folder_path)
         shutil.rmtree(pgdb_folder_path)
 
     else:
         shutil.copytree(pgdb_tmp_folder_path, output_species)
         if dat_extraction:
             for pgdb_file in os.listdir(output_species):
+                pgdb_path = os.path.join(output_species, pgdb_file)
                 if '.dat' not in pgdb_file:
-                    if os.path.isfile(output_species+'/'+pgdb_file):
-                        os.remove(output_species+'/'+pgdb_file)
-                    elif os.path.isdir(output_species+'/'+pgdb_file):
-                        shutil.rmtree(output_species+'/'+pgdb_file)
+                    if os.path.isfile(pgdb_path):
+                        os.remove(pgdb_path)
+                    elif os.path.isdir(pgdb_path):
+                        shutil.rmtree(pgdb_path)

--- a/mpwt/results_check.py
+++ b/mpwt/results_check.py
@@ -29,8 +29,8 @@ def check_pwt(multiprocess_run_pwts, patho_log_folder):
             logger.info('No log directory, it will be created.')
             os.mkdir(patho_log_folder)
 
-        patho_error_pathname = patho_log_folder + '/log_error.txt'
-        patho_resume_pathname = patho_log_folder + '/resume_inference.tsv'
+        patho_error_pathname = os.path.join(patho_log_folder, 'log_error.txt')
+        patho_resume_pathname = os.path.join(patho_log_folder, 'resume_inference.tsv')
 
         patho_error_file = open(patho_error_pathname, 'w', encoding='utf-8')
         patho_resume_file = open(patho_resume_pathname, 'w', encoding='utf-8')
@@ -42,8 +42,8 @@ def check_pwt(multiprocess_run_pwts, patho_log_folder):
 
     for multiprocess_run_pwt in multiprocess_run_pwts:
         species_input_folder_path = multiprocess_run_pwt[0]
-        species = species_input_folder_path.split('/')[-2]
-        patho_log = species_input_folder_path + '/pathologic.log'
+        species = os.path.basename(species_input_folder_path)
+        patho_log = os.path.join(species_input_folder_path, 'pathologic.log')
 
         if patho_log_folder:
             patho_error_file.write('------------ Species: ')
@@ -150,7 +150,7 @@ def check_dat(run_dat_id, species_pgdb_folder):
     """
     pgdb_folder_dbname = run_dat_id.lower() + 'cyc'
 
-    dats_path = species_pgdb_folder +'/1.0/data/'
+    dats_path = os.path.join(*[species_pgdb_folder, '1.0', 'data'])
 
     dat_files = ["classes.dat", "compound-links.dat", "compounds.dat", "dnabindsites.dat", "enzrxns.dat", "gene-links.dat", "genes.dat", "pathway-links.dat",
                 "pathways.dat", "promoters.dat", "protein-features.dat", "protein-links.dat", "proteins.dat", "protligandcplxes.dat", "pubs.dat",
@@ -158,7 +158,7 @@ def check_dat(run_dat_id, species_pgdb_folder):
 
     dat_checks = []
     for dat_file in dat_files:
-        dat_file_path = dats_path + '/' + dat_file
+        dat_file_path = os.path.join(dats_path, dat_file)
         if os.path.exists(dat_file_path):
             dat_checks.append(dat_file_path)
 

--- a/mpwt/utils.py
+++ b/mpwt/utils.py
@@ -28,7 +28,7 @@ def find_ptools_path():
 
     pathway_tools_file = open(pathway_tools_path, 'r')
     ptools_local_str = [line for line in pathway_tools_file if 'PTOOLS_LOCAL_PATH' in line][0]
-    ptools_local_path = ptools_local_str.split(';')[0].split('=')[1].replace('"', '').strip(' ') + '/ptools-local'
+    ptools_local_path = os.path.join(ptools_local_str.split(';')[0].split('=')[1].replace('"', '').strip(' '), 'ptools-local')
     pathway_tools_file.close()
 
     return ptools_local_path
@@ -39,7 +39,9 @@ def check_ptools_local_pwt():
 
     error = None
 
-    if not os.path.exists(ptools_path + '/ptools-init.dat'):
+    ptools_init_path = os.path.join(ptools_path, 'ptools-init.dat')
+
+    if not os.path.exists(ptools_init_path):
         logger.critical('Missing ptools-init.dat file in ptools-local folder. Use "pathway-tools -config" to recreate it.')
         error = True
 
@@ -56,7 +58,7 @@ def list_pgdb():
         list: PGDB IDs inside ptools-local
     """
     ptools_local_path = find_ptools_path()
-    pgdb_folder = ptools_local_path + '/pgdbs/user/'
+    pgdb_folder = os.path.join(*[ptools_local_path, 'pgdbs', 'user'])
 
     return [species_pgdb for species_pgdb in os.listdir(pgdb_folder) if 'cyc' in species_pgdb]
 
@@ -69,7 +71,7 @@ def delete_pgdb(pgdb_name):
         pgdb_name (str): PGDB ID to delete
     """
     ptools_local_path = find_ptools_path()
-    pgdb_path = ptools_local_path.replace('\n', '') +'/pgdbs/user/' + pgdb_name
+    pgdb_path = os.path.join(*[ptools_local_path.replace('\n', ''), 'pgdbs', 'user', pgdb_name])
     if os.path.isdir(pgdb_path):
         shutil.rmtree(pgdb_path)
         logger.info('{0} (at {1}) has been removed.'.format(pgdb_name, pgdb_path))
@@ -110,14 +112,14 @@ def cleaning(number_cpu=None, verbose=None):
         logger.setLevel(logging.DEBUG)
 
     ptools_local_path = find_ptools_path()
-    file_path = ptools_local_path.replace('\n', '') +'/pgdbs/user/'
+    file_path = os.path.join(*[ptools_local_path.replace('\n', ''), 'pgdbs', 'user'])
 
-    pgdb_metadata_path = file_path + 'PGDB-METADATA.ocelot'
+    pgdb_metadata_path = os.path.join(file_path, 'PGDB-METADATA.ocelot')
     if os.path.isfile(pgdb_metadata_path):
         os.remove(pgdb_metadata_path)
         logger.info('PGDB-METADATA.ocelot has been removed.')
 
-    pgdb_counter_path = file_path + 'PGDB-counter.dat'
+    pgdb_counter_path = os.path.join(file_path, 'PGDB-counter.dat')
     if os.path.isfile(pgdb_counter_path):
         os.remove(pgdb_counter_path)
         logger.info('PGDB-counter.dat has been removed.')
@@ -145,16 +147,16 @@ def cleaning_input(input_folder, verbose=None):
 
     run_ids = [folder_id for folder_id in next(os.walk(input_folder))[1]]
 
-    input_paths = [input_folder + "/" + run_id + "/" for run_id in run_ids]
+    input_paths = [os.path.join(input_folder, run_id) for run_id in run_ids]
 
     for input_path in input_paths:
         if os.path.isdir(input_path):
-            lisp_script = input_path + 'dat_creation.lisp'
-            patho_log = input_path + 'pathologic.log'
-            pwt_log = input_path + 'pwt_terminal.log'
-            dat_log = input_path + 'dat_creation.log'
-            genetic_dat = input_path + 'genetic-elements.dat'
-            organism_dat = input_path + 'organism-params.dat'
+            lisp_script = os.path.join(input_path, 'dat_creation.lisp')
+            patho_log = os.path.join(input_path, 'pathologic.log')
+            pwt_log = os.path.join(input_path, 'pwt_terminal.log')
+            dat_log = os.path.join(input_path, 'dat_creation.log')
+            genetic_dat = os.path.join(input_path, 'genetic-elements.dat')
+            organism_dat = os.path.join(input_path, 'organism-params.dat')
             if os.path.exists(lisp_script):
                 os.remove(lisp_script)
             if os.path.exists(patho_log):
@@ -167,7 +169,7 @@ def cleaning_input(input_folder, verbose=None):
                 os.remove(genetic_dat)
             if os.path.exists(organism_dat):
                 os.remove(organism_dat)
-            species = input_path.split('/')[-2]
+            species = os.path.basename(input_path)
             logger.info('Remove ' + species + ' temporary datas.')
 
 
@@ -178,7 +180,7 @@ def pubmed_citations(activate_citations):
     Args:
         activate_citations (bool): boolean to indicate if you want to activate or not the downlaod of Pubmed entries.
     """
-    ptools_init_filepath = find_ptools_path() + '/ptools-init.dat'
+    ptools_init_filepath = os.path.join(find_ptools_path(), 'ptools-init.dat')
     new_ptools_file = ""
 
     download_pubmed_entries_parameter = None
@@ -211,7 +213,7 @@ def modify_pathway_score(pathway_score):
     Args:
         pathway_score (float): score between 0 and 1 to accept or reject pathways
     """
-    ptools_init_filepath = find_ptools_path() + '/ptools-init.dat'
+    ptools_init_filepath = os.path.join(find_ptools_path() ,'ptools-init.dat')
     new_ptools_file = ""
 
     pathway_prediction_score_cutoff = None

--- a/test/test_mpwt_functions.py
+++ b/test/test_mpwt_functions.py
@@ -7,14 +7,16 @@ Test mpwt functions which don't need a Pathway-Tools environment.
 """
 
 import mpwt
+import os
 
 
 def test_create_dats_and_lisp():
-    mpwt.pathologic_input.create_dats_and_lisp('test/fatty_acid_beta_oxydation_I/', False)
+    input_path = os.path.join(*['test', 'fatty_acid_beta_oxydation_I'])
+    mpwt.pathologic_input.create_dats_and_lisp(input_path, False)
 
-    genetic_pathname = 'test/fatty_acid_beta_oxydation_I/genetic-elements.dat'
-    organism_pathname = 'test/fatty_acid_beta_oxydation_I/organism-params.dat'
-    lisp_pathname = 'test/fatty_acid_beta_oxydation_I/dat_creation.lisp'
+    genetic_pathname = os.path.join(*['test', 'fatty_acid_beta_oxydation_I', 'genetic-elements.dat'])
+    organism_pathname = os.path.join(*['test', 'fatty_acid_beta_oxydation_I', 'organism-params.dat'])
+    lisp_pathname = os.path.join(*['test', 'fatty_acid_beta_oxydation_I' , 'dat_creation.lisp'])
 
     genetic_string_expected = 'NAME\t\nANNOT-FILE\tfatty_acid_beta_oxydation_I.gbk\n//\n'
     organism_string_expected = 'ID\tfatty_acid_beta_oxydation_I\nSTORAGE\tFILE\nNCBI-TAXON-ID\t511145\nNAME\tEscherichia coli str. K-12 substr. MG1655\n'

--- a/test/test_mpwt_pathway_tools.py
+++ b/test/test_mpwt_pathway_tools.py
@@ -45,15 +45,15 @@ def test_multiprocess_pwt_import():
     mpwt.create_pathologic_file('test', 'test_pf')
     mpwt.multiprocess_pwt('test_pf', 'test_output', patho_inference=True, dat_creation=True, dat_extraction=True, size_reduction=False, number_cpu=3, verbose=True)
 
-    pathway_fabo_pathname = "test_output/fatty_acid_beta_oxydation_I_gff/pathways.dat"
+    pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_I_gff', 'pathways.dat'])
     expected_tca_reactions = reaction_extraction(pathway_fabo_pathname)
     assert set(fabo_reactions()).issubset(set(expected_tca_reactions))
 
-    pathway_fabo_pathname = "test_output/fatty_acid_beta_oxydation_I/pathways.dat"
+    pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_I', 'pathways.dat'])
     expected_fabo_reactions = reaction_extraction(pathway_fabo_pathname)
     assert set(fabo_reactions()).issubset(set(expected_fabo_reactions))
 
-    pathway_fabo_pathname = "test_output/fatty_acid_beta_oxydation_I_pf/pathways.dat"
+    pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_I_pf', 'pathways.dat'])
     expected_pf_fabo_reactions = reaction_extraction(pathway_fabo_pathname)
     assert set(fabo_reactions()).issubset(set(expected_pf_fabo_reactions))
 
@@ -76,15 +76,15 @@ def test_multiprocess_pwt_call():
     pgdbs = mpwt.list_pgdb()
     assert set(['fatty_acid_beta_oxydation_i_gffcyc', 'fatty_acid_beta_oxydation_i_pfcyc', 'fatty_acid_beta_oxydation_icyc']).issubset(set(pgdbs))
 
-    pathway_fabo_pathname = "test_output/fatty_acid_beta_oxydation_I_gff/pathways.dat"
+    pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_I_gff', 'pathways.dat'])
     expected_tca_reactions = reaction_extraction(pathway_fabo_pathname)
     assert set(fabo_reactions()).issubset(set(expected_tca_reactions))
 
-    pathway_fabo_pathname = "test_output/fatty_acid_beta_oxydation_I/pathways.dat"
+    pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_I', 'pathways.dat'])
     expected_fabo_reactions = reaction_extraction(pathway_fabo_pathname)
     assert set(fabo_reactions()).issubset(set(expected_fabo_reactions))
 
-    pathway_fabo_pathname = "test_output/fatty_acid_beta_oxydation_I_pf/pathways.dat"
+    pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_I_pf', 'pathways.dat'])
     expected_pf_fabo_reactions = reaction_extraction(pathway_fabo_pathname)
     assert set(fabo_reactions()).issubset(set(expected_pf_fabo_reactions))
 


### PR DESCRIPTION
Add:

- \_\_version\_\_ in mpwt init file to handle version (issue #59).

Fix:

- error when creating dat files without input folder (issue #61).

Modify:

- refactor how paths are handled (issue #60). This is a first step to the compatibility of mpwt on Windows. But this will need more tests and modification.