### PR TITLE
mpwt 0.6.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -788,7 +788,7 @@ Output
 If you did not use the output argument, results (PGDB with/without BioPAX/dat files) will be inside your ptools-local folder ready to be used with Pathway Tools.
 Have in mind that mpwt does not create the cellular overview and does not used the hole-filler. So if you want these results you should run them after.
 
-If you used the output argument, mpwt will move each of the PGDB folders to the output folder:
+If you use the output argument, mpwt will copy each of the PGDB folders to the output folder:
 
 .. code-block:: text
 
@@ -812,9 +812,9 @@ If you used the output argument, mpwt will move each of the PGDB folders to the 
     ├── species_3
     ..
 
-If you want specific files, you can use the --m* options.
+If you want specific files, you can use the **--mX/XXX_extraction** options.
 
-- **--md/dat_extraction** will only move the attribute-values dat files:
+- **--md/dat_extraction** will only copy the attribute-values dat files:
 
 .. code-block:: text
 
@@ -844,7 +844,7 @@ If you want specific files, you can use the --m* options.
     ├── species_3
     ..
 
-- **--mx/xml_extraction** will only move the metabolic-reactions.xml file of each PGDB and rename it:
+- **--mx/xml_extraction** will only copy the metabolic-reactions.xml file of each PGDB and rename it:
 
 .. code-block:: text
 
@@ -854,7 +854,7 @@ If you want specific files, you can use the --m* options.
     ├── species_3.xml
     ..
 
-- **--mo/owl_extraction** will only move the biopax-level2.owl and the biopax-level3.owl files of each PGDB and rename them:
+- **--mo/owl_extraction** will only copy the biopax-level2.owl and the biopax-level3.owl files of each PGDB and rename them:
 
 .. code-block:: text
 
@@ -867,7 +867,7 @@ If you want specific files, you can use the --m* options.
     ├── species_3-level3.owl
     ..
 
-- **--mc/col_extraction** will only move the tabular files of each PGDB:
+- **--mc/col_extraction** will only copy the tabular files of each PGDB:
 
 .. code-block:: text
 

--- a/README.rst
+++ b/README.rst
@@ -844,7 +844,7 @@ If you want specific files, you can use the **--mX/XXX_extraction** options.
     ├── species_3
     ..
 
-- **--mx/xml_extraction** will only copy the metabolic-reactions.xml file of each PGDB and rename it:
+- **--mx/xml_extraction** will only copy the metabolic-reactions.xml file of each PGDB (created by MetaFlux) and rename it:
 
 .. code-block:: text
 

--- a/README.rst
+++ b/README.rst
@@ -768,7 +768,7 @@ If you encounter errors (and it is highly possible) there is informations that c
 
 For error during PathoLogic inference, you can use the log arguments.
 The log contains the summary of the build and the error for each species.
-There is also a pathologic.log (created by Pathway Tools), a pwt_terminal.log (log of the terminal during PathoLogic process) and a dat_creation.log (log of the terminal during attributes-values files creation) in each sub-folders.
+There is also a pathologic.log (created by Pathway Tools), a pwt_terminal.log (log of the terminal during PathoLogic process) and a flat_files_creation.log (log of the terminal during attributes-values files creation) in each sub-folders.
 
 If the build passed you have also the possibility to see the result of the inference with the file resume_inference.tsv.
 For each species, it contains the number of genes/proteins/reactions/pathways/compounds in the metabolic network.

--- a/README.rst
+++ b/README.rst
@@ -309,11 +309,18 @@ Command Line and Python arguments
 
 By using the python multiprocessing library, mpwt launches parallel PathoLogic processes on physical cores. Regarding memory requirements, they depend on the genome but we advise to use at least 2 GB per core.
 
-mpwt can be used with the command line:
+mpwt can be used with the command lines:
 
 .. code:: sh
 
-    mpwt -f path/to/folder/input [-o path/to/folder/output] [--patho] [--hf] [--op] [--tp] [--nc] [-p FLOAT] [--dat] [--md] [--cpu INT] [-r] [--clean] [--log path/to/folder/log] [--ignore-error] [-v]
+    mpwt -f=FOLDER [-o=FOLDER] [--patho] [--hf] [--op] [--tp] [--nc] [--dat] [--md] [--mx] [--mo] [--mc] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
+    mpwt --dat [-f=FOLDER] [-o=FOLDER] [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
+    mpwt -o=FOLDER [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
+    mpwt --clean [--cpu=INT] [-v]
+    mpwt --delete=STR [--cpu=INT]
+    mpwt --list
+    mpwt --version
+    mpwt topf -f=FOLDER -o=FOLDER [--cpu=INT] [--clean]
 
 Optional argument are identified by [].
 
@@ -335,6 +342,9 @@ mpwt can be used in a python script with an import:
 			  no_download_articles=optional_boolean,
 			  dat_creation=optional_boolean,
 			  dat_extraction=optional_boolean,
+			  xml_extraction=optional_boolean,
+			  owl_extraction=optional_boolean,
+			  col_extraction=optional_boolean,
 			  size_reduction=optional_boolean,
 			  number_cpu=int,
 			  patho_log=optional_folder_pathname,
@@ -364,7 +374,13 @@ mpwt can be used in a python script with an import:
 +-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
 |          --dat          | dat_creation(boolean)                          | Create BioPAX/attribute-value dat files                                 |
 +-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
-|          --md           | dat_extraction(boolean)                        | Move only the dat files inside the output folder                        |
+|          --md           | dat_extraction(boolean)                        | Move the dat files into the output folder                               |
++-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
+|          --mx           | xml_extraction(boolean)                        | Move the metabolic-reactions.xml file into the output folder            |
++-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
+|          --mo           | owl_extraction(boolean)                        | Move owl files into the output folder                                   |
++-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
+|          --mc           | col_extraction(boolean)                        | Move tabular files into the output folder                               |
 +-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
 |          --cpu          | number_cpu(int)                                | Number of cpu used for the multiprocessing                              |
 +-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
@@ -772,9 +788,7 @@ Output
 If you did not use the output argument, results (PGDB with/without BioPAX/dat files) will be inside your ptools-local folder ready to be used with Pathway Tools.
 Have in mind that mpwt does not create the cellular overview and does not used the hole-filler. So if you want these results you should run them after.
 
-If you used the output argument, there is two potential outputs depending on the use of the option **--md/dat_extraction**:
-
-- without --md/dat_extraction, you will have a complete PGDB folder inside your results, for example:
+If you used the output argument, mpwt will move each of the PGDB folders to the output folder:
 
 .. code-block:: text
 
@@ -798,7 +812,9 @@ If you used the output argument, there is two potential outputs depending on the
     ├── species_3
     ..
 
-- with --md/dat_extraction, you will only have the dat files, for example:
+If you want specific files, you can use the --m* options.
+
+- **--md/dat_extraction** will only move the attribute-values dat files:
 
 .. code-block:: text
 
@@ -828,7 +844,89 @@ If you used the output argument, there is two potential outputs depending on the
     ├── species_3
     ..
 
-- with the **-r /size_reduction** argument, you will have compressed zip files (and PGDBs inside ptools-local will be deleted):
+- **--mx/xml_extraction** will only move the metabolic-reactions.xml file of each PGDB and rename it:
+
+.. code-block:: text
+
+    Folder_output
+    ├── species_1.xml
+    ├── species_2.xml
+    ├── species_3.xml
+    ..
+
+- **--mo/owl_extraction** will only move the biopax-level2.owl and the biopax-level3.owl files of each PGDB and rename them:
+
+.. code-block:: text
+
+    Folder_output
+    ├── species_1-level2.owl
+    ├── species_1-level3.owl
+    ├── species_2-level2.owl
+    ├── species_2-level3.owl
+    ├── species_3-level2.owl
+    ├── species_3-level3.owl
+    ..
+
+- **--mc/col_extraction** will only move the tabular files of each PGDB:
+
+.. code-block:: text
+
+    Folder_output
+    ├── species_1
+    │   └── enzymes.col
+    │   └── genes.col
+    │   └── pathways.col
+    │   └── protcplxs.col
+    │   └── transporters.col
+    ├── species_2
+    ..
+    ├── species_3
+    ..
+
+It is also possible to use a combination of these arguments:
+
+.. code:: sh
+
+    mpwt -f input_folder -f output_folder --patho --dat --md --mx --mo --mc
+
+.. code-block:: text
+
+    Folder_output
+    ├── species_1
+    │   └── biopax-level2.owl
+    │   └── biopax-level3.owl
+    │   └── classes.dat
+    │   └── compounds.dat
+    │   └── dnabindsites.dat
+    │   └── enzrxns.dat
+    │   └── enzymes.col
+    │   └── genes.col
+    │   └── genes.dat
+    │   └── metabolic-reactions.xml
+    │   └── pathways.col
+    │   └── pathways.dat
+    │   └── promoters.dat
+    │   └── protcplxs.col
+    │   └── protein-features.dat
+    │   └── proteins.dat
+    │   └── protligandcplxes.dat
+    │   └── pubs.dat
+    │   └── reactions.dat
+    │   └── regulation.dat
+    │   └── regulons.dat
+    │   └── rnas.dat
+    │   └── species.dat
+    │   └── terminators.dat
+    │   └── transporters.col
+    │   └── transunits.dat
+    │   └── ..
+    ├── species_2
+    ..
+    ├── species_3
+    ..
+
+
+By using the **-r /size_reduction** argument, you will have compressed zip files (and PGDBs inside ptools-local will be deleted):
 
 .. code-block:: text
 

--- a/README.rst
+++ b/README.rst
@@ -298,7 +298,7 @@ The species_name is extracted from the Genbank/GFF/PF files.
     ANNOT-FILE  gbk_pathname
     //
 
-    **dat_creation.lisp**
+    **flat_files_creation.lisp**
     (in-package :ecocyc)
     (select-organism :org-id 'myDBName)
     (let ((*progress-noter-enabled?* NIL))
@@ -313,8 +313,8 @@ mpwt can be used with the command lines:
 
 .. code:: sh
 
-    mpwt -f=FOLDER [-o=FOLDER] [--patho] [--hf] [--op] [--tp] [--nc] [--dat] [--md] [--mx] [--mo] [--mc] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
-    mpwt --dat [-f=FOLDER] [-o=FOLDER] [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
+    mpwt -f=FOLDER [-o=FOLDER] [--patho] [--hf] [--op] [--tp] [--nc] [--flat] [--md] [--mx] [--mo] [--mc] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
+    mpwt --flat [-f=FOLDER] [-o=FOLDER] [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
     mpwt -o=FOLDER [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
     mpwt --clean [--cpu=INT] [-v]
     mpwt --delete=STR [--cpu=INT]
@@ -340,7 +340,7 @@ mpwt can be used in a python script with an import:
 			  patho_operon_predictor=optional_boolean,
 			  patho_transporter_inference=patho_transporter_inference,
 			  no_download_articles=optional_boolean,
-			  dat_creation=optional_boolean,
+			  flat_creation=optional_boolean,
 			  dat_extraction=optional_boolean,
 			  xml_extraction=optional_boolean,
 			  owl_extraction=optional_boolean,
@@ -358,7 +358,7 @@ mpwt can be used in a python script with an import:
 +=========================+================================================+=========================================================================+
 |          -f             | input_folder(string: folder pathname)          | Input folder as described in Input data                                 |
 +-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
-|          -o             | output_folder(string: folder pathname)         | Output folder containing PGDB data or dat files (see --dat arguments)   |
+|          -o             | output_folder(string: folder pathname)         | Output folder containing PGDB data or flat files (see --flat arguments) |
 +-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
 |          --patho        | patho_inference(boolean)                       | Launch PathoLogic inference on input folder                             |
 +-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
@@ -372,7 +372,7 @@ mpwt can be used in a python script with an import:
 +-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
 |          -p             | pathway_score(float)                           | Launch PathoLogic using a specified pathway prediction score cutoff     |
 +-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
-|          --dat          | dat_creation(boolean)                          | Create BioPAX/attribute-value dat files                                 |
+|          --flat         | flat_creation(boolean)                         | Create BioPAX/attribute-value flat files                                |
 +-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
 |          --md           | dat_extraction(boolean)                        | Move the dat files into the output folder                               |
 +-------------------------+------------------------------------------------+-------------------------------------------------------------------------+
@@ -539,20 +539,20 @@ Create PGDBs of studied organisms inside ptools-local with pathway prediction sc
                             patho_inference=True,
                             pathway_score=1.0)
 
-Create PGDBs of studied organisms inside ptools-local and create dat files:
+Create PGDBs of studied organisms inside ptools-local and create flat files:
 
 ..
 
     .. code:: sh
 
-        mpwt -f path/to/folder/input --patho --dat
+        mpwt -f path/to/folder/input --patho --flat
 
     .. code:: python
 
         import mpwt
         mpwt.multiprocess_pwt(input_folder='path/to/folder/input',
                             patho_inference=True,
-                            dat_creation=True)
+                            flat_creation=True)
 
 Create PGDBs of studied organisms inside ptools-local.
 Then move all the PGDB files to the output folder.
@@ -570,14 +570,14 @@ Then move all the PGDB files to the output folder.
                             output_folder='path/to/folder/output',
                             patho_inference=True)
 
-Create PGDBs of studied organisms inside ptools-local and create dat files.
+Create PGDBs of studied organisms inside ptools-local and create flat files.
 Then move the dat files to the output folder.
 
 ..
 
     .. code:: sh
 
-        mpwt -f path/to/folder/input --patho --dat -o path/to/folder/output --md
+        mpwt -f path/to/folder/input --patho --flat -o path/to/folder/output --md
 
 
     .. code:: python
@@ -586,24 +586,24 @@ Then move the dat files to the output folder.
         mpwt.multiprocess_pwt(input_folder='path/to/folder/input',
                             output_folder='path/to/folder/output',
                             patho_inference=True,
-                            dat_creation=True,
+                            flat_creation=True,
                             dat_extraction=True)
 
 
-Create dat files for the PGDB inside ptools-local.
+Create flat files for the PGDB inside ptools-local.
 And move them to the output folder.
 
 ..
 
     .. code:: sh
 
-        mpwt --dat -o path/to/folder/output --md
+        mpwt --flat -o path/to/folder/output --md
 
     .. code:: python
 
         import mpwt
         mpwt.multiprocess_pwt(output_folder='path/to/folder/output',
-                            dat_creation=True,
+                            flat_creation=True,
                             dat_extraction=True)
 
 Move PGDB from ptools-local to the output folder:
@@ -651,7 +651,7 @@ Useful functions
                 patho_operon_predictor=optional_boolean,
                 patho_transporter_inference=patho_transporter_inference,
                 no_download_articles=optional_boolean,
-                dat_creation=optional_boolean,
+                flat_creation=optional_boolean,
                 dat_extraction=optional_boolean,
                 size_reduction=optional_boolean,
                 number_cpu=int,
@@ -676,7 +676,7 @@ Useful functions
 
         mpwt --clean
 
-    If you use clean and the argument -f input_folder, it will delete input files ('dat_creation.lisp', 'dat_creation.log', 'pathologic.log', 'pwt_terminal.log', 'genetic-elements.dat' and 'organism-params.dat') and the PGDB corresponding to the input folder.
+    If you use clean and the argument -f input_folder, it will delete input files ('flat_files_creation.lisp', 'flat_files_creation.log', 'pathologic.log', 'pwt_terminal.log', 'genetic-elements.dat' and 'organism-params.dat') and the PGDB corresponding to the input folder.
 
     .. code:: sh
 
@@ -785,7 +785,7 @@ This option will ignore error and continue the mpwt workflow on the successful P
 Output
 ~~~~~~
 
-If you did not use the output argument, results (PGDB with/without BioPAX/dat files) will be inside your ptools-local folder ready to be used with Pathway Tools.
+If you did not use the output argument, results (PGDB with/without BioPAX/flat files) will be inside your ptools-local folder ready to be used with Pathway Tools.
 Have in mind that mpwt does not create the cellular overview and does not used the hole-filler. So if you want these results you should run them after.
 
 If you use the output argument, mpwt will copy each of the PGDB folders to the output folder:
@@ -797,7 +797,7 @@ If you use the output argument, mpwt will copy each of the PGDB folders to the o
     │   └── default-version
     │   └── 1.0
     │       └── data
-    │           └── contains BioPAX/dat files if you used the --dat/dat_creation option.
+    │           └── contains BioPAX/flat files if you used the --flat/flat_creation option.
     │       └── input
     │           └── species_1.gbk
     │           └── genetic-elements.dat
@@ -887,7 +887,7 @@ It is also possible to use a combination of these arguments:
 
 .. code:: sh
 
-    mpwt -f input_folder -o output_folder --patho --dat --md --mx --mo --mc
+    mpwt -f input_folder -o output_folder --patho --flat --md --mx --mo --mc
 
 .. code-block:: text
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ mpwt: Multiprocessing Pathway Tools
 
 mpwt is a python package for running Pathway Tools [Karp2019]_ on multiple genomes using multiprocessing. More precisely, it launches one PathoLogic [Karp2011]_ process for each organism. This allows to increase the speed of draft metabolic network reconstruction when working on multiple organisms.
 
-There is no guarantee that this script will work, it is a Work In Progress in early state.
+The last version of Pathway Tools supported by mpwt is shown in the badge named "Pathway Tools".
 
 mpwt: Pipeline summary
 ======================
@@ -31,10 +31,10 @@ Installation
 Requirements
 ~~~~~~~~~~~~
 
-mpwt needs at least **Python3.6**.
+mpwt needs at least **Python 3.6**.
 mpwt requires three python depedencies (`biopython <https://github.com/biopython/biopython>`__, `docopt <https://github.com/docopt/docopt>`__ and `gffutils <https://github.com/daler/gffutils>`__) and **Pathway Tools**. For the multiprocessing, mpwt uses the `multiprocessing library of Python 3 <https://docs.python.org/3/library/multiprocessing.html>`__.
 
-You must have an environment where Pathway Tools is installed. Pathway Tools can be obtained `here <http://bioinformatics.ai.sri.com/ptools/>`__. The last version supported by mpwt is shown in the badge Pathway Tools.
+You must have an environment where Pathway Tools is installed. Pathway Tools can be obtained `here <http://bioinformatics.ai.sri.com/ptools/>`__.
 
 Pathway Tools needs **Blast**, so it must be install on your system. Depending on your system, Pathway Tools needs a file named **.ncbirc** to locate Blast, for more informations look at `this page <http://bioinformatics.ai.sri.com/ptools/installation-guide/released/blast.html>`__.
 
@@ -887,7 +887,7 @@ It is also possible to use a combination of these arguments:
 
 .. code:: sh
 
-    mpwt -f input_folder -f output_folder --patho --dat --md --mx --mo --mc
+    mpwt -f input_folder -o output_folder --patho --dat --md --mx --mo --mc
 
 .. code-block:: text
 

--- a/mpwt/__init__.py
+++ b/mpwt/__init__.py
@@ -3,4 +3,4 @@ from mpwt.mpwt_workflow import multiprocess_pwt
 from mpwt.utils import cleaning, cleaning_input, find_ptools_path, list_pgdb, pubmed_citations, remove_pgdbs
 from mpwt.to_pathologic import create_pathologic_file
 
-__version__='0.5.9'
+__version__='0.6.0'

--- a/mpwt/__init__.py
+++ b/mpwt/__init__.py
@@ -1,4 +1,4 @@
-from mpwt.pwt_wrapper import run_pwt, run_pwt_dat
+from mpwt.pwt_wrapper import run_pwt, run_pwt_flat
 from mpwt.mpwt_workflow import multiprocess_pwt
 from mpwt.utils import cleaning, cleaning_input, find_ptools_path, list_pgdb, pubmed_citations, remove_pgdbs
 from mpwt.to_pathologic import create_pathologic_file

--- a/mpwt/__main__.py
+++ b/mpwt/__main__.py
@@ -7,9 +7,9 @@ From Genbank/GFF/PF files this script will create Pathway Tools input data, then
 The script takes a folder name as argument.
 
 usage:
-    mpwt -f=DIR [-o=DIR] [--patho] [--hf] [--op] [--tp] [--nc] [--dat] [--md] [--mx] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
-    mpwt --dat [-f=DIR] [-o=DIR] [--md] [--cpu=INT] [-v]
-    mpwt -o=DIR [--md] [--cpu=INT] [-v]
+    mpwt -f=DIR [-o=DIR] [--patho] [--hf] [--op] [--tp] [--nc] [--dat] [--md] [--mx] [--mo] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
+    mpwt --dat [-f=DIR] [-o=DIR] [--md] [--mx] [--mo] [--cpu=INT] [-v]
+    mpwt -o=DIR [--md] [--mx] [--mo] [--cpu=INT] [-v]
     mpwt --clean [--cpu=INT] [-v]
     mpwt --delete=STR [--cpu=INT]
     mpwt --list
@@ -27,8 +27,9 @@ options:
     --nc    Use with --patho. Turn off loading of Pubmed entries.
     -p=FLOAT   Use with --patho. Modify PathoLogic pathway prediction score.
     --dat    Will create BioPAX/attribute-value dat files from PGDB.
-    --md    Move only the dat files into the output folder.
-    --mx    Move only the metabolic-reactions.xml file into the output folder.
+    --md    Move the dat files into the output folder.
+    --mx    Move the metabolic-reactions.xml file into the output folder.
+    --mo    Move owl files into the output folder.
     --clean    Clean ptools-local folder, before any other operations.
     --delete=STR    Give a PGDB name and it will delete it (if multiple separe them with a ',', example: ecolicyc,athalianacyc).
     -r    Will delete files in ptools-local and compress results files to reduce results size (use it with -o).
@@ -80,6 +81,7 @@ def run_mpwt():
     dat_creation = args['--dat']
     move_dat = args['--md']
     move_xml = args['--mx']
+    move_owl = args['--mo']
     size_reduction = args['-r']
     number_cpu = args['--cpu']
     patho_log = args['--log']
@@ -143,6 +145,7 @@ def run_mpwt():
                     dat_creation=dat_creation,
                     dat_extraction=move_dat,
                     xml_extraction=move_xml,
+                    owl_extraction=move_owl,
                     size_reduction=size_reduction,
                     number_cpu=number_cpu,
                     patho_log=patho_log,

--- a/mpwt/__main__.py
+++ b/mpwt/__main__.py
@@ -3,12 +3,12 @@
 
 """
 Description:
-From Genbank/GFF/PF files this script will create Pathway Tools input data, then run Pathway Tools's PathoLogic on them. It can also generate dat files.
+From Genbank/GFF/PF files this script will create Pathway Tools input data, then run Pathway Tools's PathoLogic on them. It can also generate flat files.
 The script takes a folder name as argument.
 
 usage:
-    mpwt -f=FOLDER [-o=FOLDER] [--patho] [--hf] [--op] [--tp] [--nc] [--dat] [--md] [--mx] [--mo] [--mc] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
-    mpwt --dat [-f=FOLDER] [-o=FOLDER] [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
+    mpwt -f=FOLDER [-o=FOLDER] [--patho] [--hf] [--op] [--tp] [--nc] [--flat] [--md] [--mx] [--mo] [--mc] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
+    mpwt --flat [-f=FOLDER] [-o=FOLDER] [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
     mpwt -o=FOLDER [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
     mpwt --clean [--cpu=INT] [-v]
     mpwt --delete=STR [--cpu=INT]
@@ -26,7 +26,7 @@ options:
     --tp    Use with --patho. Run the Transport Inference Parser of Pathway-Tools.
     --nc    Use with --patho. Turn off loading of Pubmed entries.
     -p=FLOAT   Use with --patho. Modify PathoLogic pathway prediction score.
-    --dat    Will create BioPAX/attribute-value dat files from PGDB.
+    --flat    Will create BioPAX/attribute-value flat files from PGDB.
     --md    Move the dat files into the output folder.
     --mx    Move the metabolic-reactions.xml file into the output folder.
     --mo    Move owl files into the output folder.
@@ -37,7 +37,7 @@ options:
     --cpu=INT     Number of cpu to use for the multiprocessing (default=1). [default: 1]
     --log=FOLDER     Create PathoLogic log files inside the given folder (use it with --patho).
     --list     List all PGDBs inside the ptools-local folder.
-    --ignore-error     Ignore errors (PathoLogic and dat creation) and continue for successful builds.
+    --ignore-error     Ignore errors (PathoLogic and flat-files creation) and continue for successful builds.
     --taxon-file     For the use of the taxon_id.tsv file to find the taxon ID.
     -v     Verbose.
     --version     Version
@@ -79,7 +79,7 @@ def run_mpwt():
     patho_operon_predictor = args['--op']
     patho_transporter_inference = args['--tp']
     no_download_articles = args['--nc']
-    dat_creation = args['--dat']
+    flat_creation = args['--flat']
     move_dat = args['--md']
     move_xml = args['--mx']
     move_owl = args['--mo']
@@ -129,7 +129,7 @@ def run_mpwt():
             utils.remove_pgdbs(input_pgdb_to_deletes, number_cpu)
         else:
             utils.cleaning(number_cpu, verbose)
-        if not patho_inference and not dat_creation and not move_dat and not output_folder:
+        if not patho_inference and not flat_creation and not move_dat and not output_folder:
             sys.exit()
 
     if topf:
@@ -144,7 +144,7 @@ def run_mpwt():
                     patho_operon_predictor=patho_operon_predictor,
                     patho_transporter_inference=patho_transporter_inference,
                     no_download_articles=no_download_articles,
-                    dat_creation=dat_creation,
+                    flat_creation=flat_creation,
                     dat_extraction=move_dat,
                     xml_extraction=move_xml,
                     owl_extraction=move_owl,

--- a/mpwt/__main__.py
+++ b/mpwt/__main__.py
@@ -7,7 +7,7 @@ From Genbank/GFF/PF files this script will create Pathway Tools input data, then
 The script takes a folder name as argument.
 
 usage:
-    mpwt -f=DIR [-o=DIR] [--patho] [--hf] [--op] [--tp] [--nc] [--dat] [--md] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
+    mpwt -f=DIR [-o=DIR] [--patho] [--hf] [--op] [--tp] [--nc] [--dat] [--md] [--mx] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
     mpwt --dat [-f=DIR] [-o=DIR] [--md] [--cpu=INT] [-v]
     mpwt -o=DIR [--md] [--cpu=INT] [-v]
     mpwt --clean [--cpu=INT] [-v]
@@ -28,6 +28,7 @@ options:
     -p=FLOAT   Use with --patho. Modify PathoLogic pathway prediction score.
     --dat    Will create BioPAX/attribute-value dat files from PGDB.
     --md    Move only the dat files into the output folder.
+    --mx    Move only the metabolic-reactions.xml file into the output folder.
     --clean    Clean ptools-local folder, before any other operations.
     --delete=STR    Give a PGDB name and it will delete it (if multiple separe them with a ',', example: ecolicyc,athalianacyc).
     -r    Will delete files in ptools-local and compress results files to reduce results size (use it with -o).
@@ -78,6 +79,7 @@ def run_mpwt():
     no_download_articles = args['--nc']
     dat_creation = args['--dat']
     move_dat = args['--md']
+    move_xml = args['--mx']
     size_reduction = args['-r']
     number_cpu = args['--cpu']
     patho_log = args['--log']
@@ -140,6 +142,7 @@ def run_mpwt():
                     no_download_articles=no_download_articles,
                     dat_creation=dat_creation,
                     dat_extraction=move_dat,
+                    xml_extraction=move_xml,
                     size_reduction=size_reduction,
                     number_cpu=number_cpu,
                     patho_log=patho_log,

--- a/mpwt/__main__.py
+++ b/mpwt/__main__.py
@@ -7,9 +7,9 @@ From Genbank/GFF/PF files this script will create Pathway Tools input data, then
 The script takes a folder name as argument.
 
 usage:
-    mpwt -f=DIR [-o=DIR] [--patho] [--hf] [--op] [--tp] [--nc] [--dat] [--md] [--mx] [--mo] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
-    mpwt --dat [-f=DIR] [-o=DIR] [--md] [--mx] [--mo] [--cpu=INT] [-v]
-    mpwt -o=DIR [--md] [--mx] [--mo] [--cpu=INT] [-v]
+    mpwt -f=DIR [-o=DIR] [--patho] [--hf] [--op] [--tp] [--nc] [--dat] [--md] [--mx] [--mo] [--mc] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
+    mpwt --dat [-f=DIR] [-o=DIR] [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
+    mpwt -o=DIR [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
     mpwt --clean [--cpu=INT] [-v]
     mpwt --delete=STR [--cpu=INT]
     mpwt --list
@@ -30,6 +30,7 @@ options:
     --md    Move the dat files into the output folder.
     --mx    Move the metabolic-reactions.xml file into the output folder.
     --mo    Move owl files into the output folder.
+    --mc    Move tabular files into the output folder.
     --clean    Clean ptools-local folder, before any other operations.
     --delete=STR    Give a PGDB name and it will delete it (if multiple separe them with a ',', example: ecolicyc,athalianacyc).
     -r    Will delete files in ptools-local and compress results files to reduce results size (use it with -o).
@@ -82,6 +83,7 @@ def run_mpwt():
     move_dat = args['--md']
     move_xml = args['--mx']
     move_owl = args['--mo']
+    move_col = args['--mc']
     size_reduction = args['-r']
     number_cpu = args['--cpu']
     patho_log = args['--log']
@@ -146,6 +148,7 @@ def run_mpwt():
                     dat_extraction=move_dat,
                     xml_extraction=move_xml,
                     owl_extraction=move_owl,
+                    col_extraction=move_col,
                     size_reduction=size_reduction,
                     number_cpu=number_cpu,
                     patho_log=patho_log,

--- a/mpwt/__main__.py
+++ b/mpwt/__main__.py
@@ -7,19 +7,19 @@ From Genbank/GFF/PF files this script will create Pathway Tools input data, then
 The script takes a folder name as argument.
 
 usage:
-    mpwt -f=DIR [-o=DIR] [--patho] [--hf] [--op] [--tp] [--nc] [--dat] [--md] [--mx] [--mo] [--mc] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
-    mpwt --dat [-f=DIR] [-o=DIR] [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
-    mpwt -o=DIR [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
+    mpwt -f=FOLDER [-o=FOLDER] [--patho] [--hf] [--op] [--tp] [--nc] [--dat] [--md] [--mx] [--mo] [--mc] [-p=FLOAT] [--cpu=INT] [-r] [-v] [--clean] [--log=FOLDER] [--ignore-error] [--taxon-file]
+    mpwt --dat [-f=FOLDER] [-o=FOLDER] [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
+    mpwt -o=FOLDER [--md] [--mx] [--mo] [--mc] [--cpu=INT] [-v]
     mpwt --clean [--cpu=INT] [-v]
     mpwt --delete=STR [--cpu=INT]
     mpwt --list
     mpwt --version
-    mpwt topf -f=DIR -o=DIR [--cpu=INT] [--clean]
+    mpwt topf -f=FOLDER -o=FOLDER [--cpu=INT] [--clean]
 
 options:
     -h --help     Show help.
-    -f=DIR     Working folder containing sub-folders with Genbank/GFF/PF files.
-    -o=DIR    Output folder path. Will create a output folder in this folder.
+    -f=FOLDER     Working folder containing sub-folders with Genbank/GFF/PF files.
+    -o=FOLDER    Output folder path. Will create a output folder in this folder.
     --patho    Will run an inference of Pathologic on the input files.
     --hf    Use with --patho. Run the Hole Filler using Blast.
     --op    Use with --patho. Run the Operon predictor of Pathway-Tools.

--- a/mpwt/mpwt_workflow.py
+++ b/mpwt/mpwt_workflow.py
@@ -15,7 +15,7 @@ import time
 from mpwt import utils
 from mpwt.pwt_wrapper import run_pwt, run_pwt_dat, run_move_pgdb
 from mpwt.results_check import check_dat, check_pwt
-from mpwt.pathologic_input import check_input_and_existing_pgdb, create_mpwt_input, pwt_input_files, create_only_dat_lisp, create_dat_creation_script, read_taxon_id, retrieve_complete_id
+from mpwt.pathologic_input import check_input_and_existing_pgdb, pwt_input_files, create_only_dat_lisp, create_dat_creation_script, read_taxon_id
 from multiprocessing import Pool
 
 logger = logging.getLogger(__name__)
@@ -219,8 +219,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
     # Create path for lisp if there is no folder given.
     # Create the input for the creation of BioPAX/attribute-values files.
     if (dat_creation and not input_folder) or (output_folder and not input_folder):
-        only_dat_creation = True
-        # Create a temporary folder in ptools-local where list script will be stored.
+        # Create a temporary folder in ptools-local where lisp script will be stored.
         tmp_folder = os.path.join(ptools_local_path, 'tmp')
         if not os.path.exists(tmp_folder):
             os.mkdir(tmp_folder)
@@ -233,8 +232,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
             input_tmp_folder_path = os.path.join(tmp_folder, dat_run_id)
             species_pgdb_folder = os.path.join(pgdbs_folder_path, dat_run_id.lower() + 'cyc')
             input_run_move_pgdbs = [dat_run_id, species_pgdb_folder]
-            if only_dat_creation:
-                input_run_move_pgdbs = retrieve_complete_id(input_run_move_pgdbs)
+
             input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction, owl_extraction, col_extraction])
             multiprocess_run_pwt_dats.append([input_tmp_folder_path])
             multiprocess_run_move_pgdbs.append(input_run_move_pgdbs)

--- a/mpwt/mpwt_workflow.py
+++ b/mpwt/mpwt_workflow.py
@@ -24,9 +24,10 @@ logger = logging.getLogger(__name__)
 def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None,
                      patho_hole_filler=None, patho_operon_predictor=None,
                      patho_transporter_inference=None, no_download_articles=None,
-                     dat_creation=None, dat_extraction=None, size_reduction=None,
-                     number_cpu=None, patho_log=None, ignore_error=None,
-                     pathway_score=None, taxon_file=None, verbose=None):
+                     dat_creation=None, dat_extraction=None, xml_extraction=None,
+                     size_reduction=None, number_cpu=None, patho_log=None,
+                     ignore_error=None, pathway_score=None, taxon_file=None,
+                     verbose=None):
     """
     Function managing all the workflow (from the creatin of the input files to the results).
     Use it when you import mpwt in a script.
@@ -41,6 +42,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
         no_download_articles (bool): turning off loading of PubMed citations (True/False)
         dat_creation (bool): BioPAX/attributes-values files creation (True/False)
         dat_extraction (bool): move only BioPAX/attributes-values files to output folder (True/False)
+        xml_extraction (bool): move only metabolic-reactions.xml to output folder (True/False)
         size_reduction (bool): delete ptools-local data at the end (True/False)
         number_cpu (int): number of CPU used (default=1)
         patho_log (str): pathname to mpwt log folder
@@ -100,9 +102,17 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
     if pathway_score and not patho_inference:
         sys.exit('To use -p/pathway_score, you need to use the --patho/patho_inference argument.')
 
-    #Check if no_download_articles is used with patho_inference.
+    #Check if no_download_articles is used with output_folder.
     if dat_extraction and not output_folder:
         sys.exit('To use --md/dat_extraction, you need to use the -o/output_folder argument.')
+
+    #Check if xml_extraction is used with output_folder.
+    if xml_extraction and not output_folder:
+        sys.exit('To use --mx/xml_extraction, you need to use the -o/output_folder argument.')
+
+    #Check if no_download_articles is used with patho_inference.
+    if dat_extraction and xml_extraction:
+        sys.exit('--mx/xml_extraction is incompatible with --md/dat_extraction.')
 
     # Use the number of cpu given by the user or 1 CPU.
     if number_cpu:
@@ -159,7 +169,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
                 input_folder_path = os.path.join(input_folder, run_patho_dat_id)
                 species_pgdb_folder = os.path.join(pgdbs_folder_path, run_patho_dat_id.lower() + 'cyc')
                 input_run_move_pgdbs = [run_patho_dat_id, species_pgdb_folder]
-                input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction])
+                input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction])
                 multiprocess_pwt_input_files.append([input_folder_path, taxon_file])
                 multiprocess_run_pwts.append([input_folder_path, patho_hole_filler, patho_operon_predictor, patho_transporter_inference])
                 multiprocess_run_pwt_dats.append([input_folder_path])
@@ -219,7 +229,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
             input_run_move_pgdbs = [dat_run_id, species_pgdb_folder]
             if only_dat_creation:
                 input_run_move_pgdbs = retrieve_complete_id(input_run_move_pgdbs)
-            input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction])
+            input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction])
             multiprocess_run_pwt_dats.append([input_tmp_folder_path])
             multiprocess_run_move_pgdbs.append(input_run_move_pgdbs)
 
@@ -247,7 +257,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
                 species_pgdb_folder = os.path.join(pgdbs_folder_path, run_dat_id.lower() + 'cyc')
                 multiprocess_run_pwt_dats.append([input_folder_path])
                 input_run_move_pgdbs = [run_dat_id, species_pgdb_folder]
-                input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction])
+                input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction])
                 multiprocess_run_move_pgdbs.append(input_run_move_pgdbs)
 
     if not multiprocess_run_pwt_dats:

--- a/mpwt/mpwt_workflow.py
+++ b/mpwt/mpwt_workflow.py
@@ -25,9 +25,9 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
                      patho_hole_filler=None, patho_operon_predictor=None,
                      patho_transporter_inference=None, no_download_articles=None,
                      dat_creation=None, dat_extraction=None, xml_extraction=None,
-                     size_reduction=None, number_cpu=None, patho_log=None,
-                     ignore_error=None, pathway_score=None, taxon_file=None,
-                     verbose=None):
+                     owl_extraction=None, size_reduction=None, number_cpu=None,
+                     patho_log=None, ignore_error=None, pathway_score=None,
+                     taxon_file=None, verbose=None):
     """
     Function managing all the workflow (from the creatin of the input files to the results).
     Use it when you import mpwt in a script.
@@ -41,8 +41,9 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
         patho_transporter_inference (bool): PathoLogic Transport Inference Parser (True/False)
         no_download_articles (bool): turning off loading of PubMed citations (True/False)
         dat_creation (bool): BioPAX/attributes-values files creation (True/False)
-        dat_extraction (bool): move only BioPAX/attributes-values files to output folder (True/False)
-        xml_extraction (bool): move only metabolic-reactions.xml to output folder (True/False)
+        dat_extraction (bool): move BioPAX/attributes-values files to output folder (True/False)
+        xml_extraction (bool): move metabolic-reactions.xml to output folder (True/False)
+        owl_extraction (bool): move owl files to output folder (True/False)
         size_reduction (bool): delete ptools-local data at the end (True/False)
         number_cpu (int): number of CPU used (default=1)
         patho_log (str): pathname to mpwt log folder
@@ -110,9 +111,9 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
     if xml_extraction and not output_folder:
         sys.exit('To use --mx/xml_extraction, you need to use the -o/output_folder argument.')
 
-    #Check if no_download_articles is used with patho_inference.
-    if dat_extraction and xml_extraction:
-        sys.exit('--mx/xml_extraction is incompatible with --md/dat_extraction.')
+    #Check if owl_extraction is used with output_folder.
+    if owl_extraction and not output_folder:
+        sys.exit('To use --mo/owl_extraction, you need to use the -o/output_folder argument.')
 
     # Use the number of cpu given by the user or 1 CPU.
     if number_cpu:
@@ -169,7 +170,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
                 input_folder_path = os.path.join(input_folder, run_patho_dat_id)
                 species_pgdb_folder = os.path.join(pgdbs_folder_path, run_patho_dat_id.lower() + 'cyc')
                 input_run_move_pgdbs = [run_patho_dat_id, species_pgdb_folder]
-                input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction])
+                input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction, owl_extraction])
                 multiprocess_pwt_input_files.append([input_folder_path, taxon_file])
                 multiprocess_run_pwts.append([input_folder_path, patho_hole_filler, patho_operon_predictor, patho_transporter_inference])
                 multiprocess_run_pwt_dats.append([input_folder_path])
@@ -229,7 +230,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
             input_run_move_pgdbs = [dat_run_id, species_pgdb_folder]
             if only_dat_creation:
                 input_run_move_pgdbs = retrieve_complete_id(input_run_move_pgdbs)
-            input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction])
+            input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction, owl_extraction])
             multiprocess_run_pwt_dats.append([input_tmp_folder_path])
             multiprocess_run_move_pgdbs.append(input_run_move_pgdbs)
 
@@ -257,7 +258,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
                 species_pgdb_folder = os.path.join(pgdbs_folder_path, run_dat_id.lower() + 'cyc')
                 multiprocess_run_pwt_dats.append([input_folder_path])
                 input_run_move_pgdbs = [run_dat_id, species_pgdb_folder]
-                input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction])
+                input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction, owl_extraction])
                 multiprocess_run_move_pgdbs.append(input_run_move_pgdbs)
 
     if not multiprocess_run_pwt_dats:

--- a/mpwt/mpwt_workflow.py
+++ b/mpwt/mpwt_workflow.py
@@ -25,9 +25,9 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
                      patho_hole_filler=None, patho_operon_predictor=None,
                      patho_transporter_inference=None, no_download_articles=None,
                      dat_creation=None, dat_extraction=None, xml_extraction=None,
-                     owl_extraction=None, size_reduction=None, number_cpu=None,
-                     patho_log=None, ignore_error=None, pathway_score=None,
-                     taxon_file=None, verbose=None):
+                     owl_extraction=None, col_extraction=None, size_reduction=None,
+                     number_cpu=None, patho_log=None, ignore_error=None,
+                     pathway_score=None, taxon_file=None, verbose=None):
     """
     Function managing all the workflow (from the creatin of the input files to the results).
     Use it when you import mpwt in a script.
@@ -44,6 +44,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
         dat_extraction (bool): move BioPAX/attributes-values files to output folder (True/False)
         xml_extraction (bool): move metabolic-reactions.xml to output folder (True/False)
         owl_extraction (bool): move owl files to output folder (True/False)
+        col_extraction (bool): move tabular files to output folder (True/False)
         size_reduction (bool): delete ptools-local data at the end (True/False)
         number_cpu (int): number of CPU used (default=1)
         patho_log (str): pathname to mpwt log folder
@@ -115,6 +116,10 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
     if owl_extraction and not output_folder:
         sys.exit('To use --mo/owl_extraction, you need to use the -o/output_folder argument.')
 
+    #Check if col_extraction is used with output_folder.
+    if col_extraction and not output_folder:
+        sys.exit('To use --mc/col_extraction, you need to use the -o/output_folder argument.')
+
     # Use the number of cpu given by the user or 1 CPU.
     if number_cpu:
         try:
@@ -170,7 +175,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
                 input_folder_path = os.path.join(input_folder, run_patho_dat_id)
                 species_pgdb_folder = os.path.join(pgdbs_folder_path, run_patho_dat_id.lower() + 'cyc')
                 input_run_move_pgdbs = [run_patho_dat_id, species_pgdb_folder]
-                input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction, owl_extraction])
+                input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction, owl_extraction, col_extraction])
                 multiprocess_pwt_input_files.append([input_folder_path, taxon_file])
                 multiprocess_run_pwts.append([input_folder_path, patho_hole_filler, patho_operon_predictor, patho_transporter_inference])
                 multiprocess_run_pwt_dats.append([input_folder_path])
@@ -230,7 +235,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
             input_run_move_pgdbs = [dat_run_id, species_pgdb_folder]
             if only_dat_creation:
                 input_run_move_pgdbs = retrieve_complete_id(input_run_move_pgdbs)
-            input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction, owl_extraction])
+            input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction, owl_extraction, col_extraction])
             multiprocess_run_pwt_dats.append([input_tmp_folder_path])
             multiprocess_run_move_pgdbs.append(input_run_move_pgdbs)
 
@@ -258,7 +263,7 @@ def multiprocess_pwt(input_folder=None, output_folder=None, patho_inference=None
                 species_pgdb_folder = os.path.join(pgdbs_folder_path, run_dat_id.lower() + 'cyc')
                 multiprocess_run_pwt_dats.append([input_folder_path])
                 input_run_move_pgdbs = [run_dat_id, species_pgdb_folder]
-                input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction, owl_extraction])
+                input_run_move_pgdbs.extend([dat_extraction, output_folder, size_reduction, xml_extraction, owl_extraction, col_extraction])
                 multiprocess_run_move_pgdbs.append(input_run_move_pgdbs)
 
     if not multiprocess_run_pwt_dats:

--- a/mpwt/pathologic_input.py
+++ b/mpwt/pathologic_input.py
@@ -617,50 +617,6 @@ def pwt_input_files(run_folder, taxon_file):
     return error_found
 
 
-def create_mpwt_input(run_ids, input_folder, pgdbs_folder_path,
-                      patho_hole_filler=None, patho_operon_predictor=None,
-                      dat_extraction=None, output_folder=None,
-                      size_reduction=None, only_dat_creation=None,
-                      taxon_file=None):
-    """
-    Create input list for all multiprocess function, containing one lsit for each input subfolder.
-    All arguments are also stored.
-
-    Args:
-        run_ids (list): input species IDs
-        input_folder (str): pathname to input folder
-        pgdbs_folder_path (str): pathname to species PGDB in ptools-local
-        patho_hole_filler (bool): PathoLogic Hole Filler argument
-        patho_operon_predictor (bool): PathoLogic Operon predictor argument
-        dat_extraction (bool): BioPAX/attribute-values file extraction argument
-        output_folder (str): pathname to output folder
-        size_reduction (bool): ptools-local PGDB deletion after processing argument
-        only_dat_creation (bool): only create BioPAX/attribute values argument
-    Returns:
-        dictionary: contain all these data for multiprocessing
-    """
-    multiprocess_inputs = []
-    for run_id in run_ids:
-        multiprocess_input = {}
-        input_folder_path = os.path.join(input_folder, run_id)
-        species_pgdb_folder = os.path.join(pgdbs_folder_path, run_id.lower() + 'cyc')
-        pgdb_id_folders = (run_id, species_pgdb_folder)
-        if only_dat_creation:
-            multiprocess_input['pgdb_folders'] = retrieve_complete_id(pgdb_id_folders)
-        else:
-            multiprocess_input['pgdb_folders'] = pgdb_id_folders
-        multiprocess_input['species_input_folder_path'] = input_folder_path
-        multiprocess_input['patho_hole_filler'] = patho_hole_filler
-        multiprocess_input['patho_operon_predictor'] = patho_operon_predictor
-        multiprocess_input['dat_extraction'] = dat_extraction
-        multiprocess_input['output_folder'] = output_folder
-        multiprocess_input['size_reduction'] = size_reduction
-        multiprocess_input['taxon_file'] = taxon_file
-        multiprocess_inputs.append(multiprocess_input)
-
-    return multiprocess_inputs
-
-
 def create_only_dat_lisp(pgdbs_folder_path, tmp_folder):
     """
     Create a lisp script file for each PGDB in the ptools-local folder.
@@ -685,21 +641,3 @@ def create_only_dat_lisp(pgdbs_folder_path, tmp_folder):
                 raise Exception('Error with the creation of the lisp script for {0}'.format(species_pgdb))
 
             yield pgdb_id
-
-
-def retrieve_complete_id(pgdb_id_folder):
-    """
-    Retrieve the ID of the PGDB from the genetic-elements.dat file.
-
-    Args:
-        pgdb_id_folder (list): second tuple argument is the pathname to the PGDB
-    Returns:
-        list: (new PGDB ID (according to input file), pathname to PGDB folder)
-    """
-    genetic_element_path = os.path.join(*[pgdb_id_folder[1], '1.0', 'input', 'genetic-elements.dat'])
-    with open(genetic_element_path) as organism_file:
-        for line in organism_file:
-            if 'ANNOT-FILE' in line and ';;' not in line:
-                pgdb_id_complete = line.split('\t')[1].replace('.gff','').replace('.gbk','').strip()
-
-    return [pgdb_id_complete, pgdb_id_folder[1]]

--- a/mpwt/pathologic_input.py
+++ b/mpwt/pathologic_input.py
@@ -39,7 +39,7 @@ def compare_input_ids_to_ptools_ids(compare_ids, ptools_run_ids, set_operation):
         compare_ids_ptools = set(lower_case_compare_ids) - set(ptools_run_ids)
 
     # Intersection to obtain all IDs which are already in PGDB folder.
-    # Which need only to create BioPAX/dat files and move them in output folder.
+    # Which need only to create BioPAX/flat files and move them in output folder.
     elif set_operation == 'intersection':
         compare_ids_ptools = set(ptools_run_ids).intersection(set(lower_case_compare_ids))
 
@@ -57,8 +57,8 @@ def check_input_and_existing_pgdb(run_ids, input_folder, output_folder, number_c
         output_folder (str): pathname to the output folder
         number_cpu_to_use (int): number of CPU to use for multiprocessing
     Returns:
-        list: input IDs for PathoLogic and BioPAX/dat creation
-        list: input IDs for BioPAX/dat creation
+        list: input IDs for PathoLogic and BioPAX/flat files creation
+        list: input IDs for BioPAX/flat files creation
     """
     # Check if there are files/folders inside the input folder.
     # And remove hidden folder/file (beginning with '.').
@@ -164,18 +164,18 @@ def check_input_and_existing_pgdb(run_ids, input_folder, output_folder, number_c
 
         already_present_pgdbs = list(set(already_present_pgdbs) - set(unfinished_builds))
 
-        run_patho_dat_ids = compare_input_ids_to_ptools_ids(new_run_ids, already_present_pgdbs, 'difference')
-        run_dat_ids = compare_input_ids_to_ptools_ids(new_run_ids, already_present_pgdbs, 'intersection')
+        run_patho_flat_ids = compare_input_ids_to_ptools_ids(new_run_ids, already_present_pgdbs, 'difference')
+        run_flat_ids = compare_input_ids_to_ptools_ids(new_run_ids, already_present_pgdbs, 'intersection')
 
-        for run_dat_id in run_dat_ids:
-            logger.info("! PGDB {0} already in ptools-local, no PathoLogic inference will be launched on this species.".format(run_dat_id))
-        return run_patho_dat_ids, run_dat_ids
+        for run_flat_id in run_flat_ids:
+            logger.info("! PGDB {0} already in ptools-local, no PathoLogic inference will be launched on this species.".format(run_flat_id))
+        return run_patho_flat_ids, run_flat_ids
 
     return new_run_ids, None
 
 
-def create_dat_creation_script(pgdb_id, lisp_pathname):
-    """ Create a lisp script allowing dat extraction.
+def create_flat_creation_script(pgdb_id, lisp_pathname):
+    """ Create a lisp script allowing flat files creation.
 
     Args:
         pgdb_id (str): ID of a PGDB
@@ -323,10 +323,10 @@ def extract_taxon_id(run_folder, pgdb_id, taxon_id, taxon_file):
     return False, taxon_id, taxon_datas
 
 
-def create_dats_and_lisp(run_folder, taxon_file):
+def create_flats_and_lisp(run_folder, taxon_file):
     """
     Read Genbank/GFF/PF files and create Pathway Tools needed file.
-    Create also a lisp file to create dat files from Pathway tools results.
+    Create also a lisp file to create flat files from Pathway tools results.
     The name of the PGDB created by Pathway Tools will be the name of the species with '_' instead of space.
 
     Create organism-params.dat:
@@ -340,7 +340,7 @@ def create_dats_and_lisp(run_folder, taxon_file):
     ANNOT-FILE  gbk_name
     //
 
-    Create dat_creation.lisp:
+    Create flat_files_creation.lisp:
     (in-package :ecocyc)
     (select-organism :org-id 'pgdb_id)
     (create-flat-files-for-current-kb)
@@ -362,7 +362,7 @@ def create_dats_and_lisp(run_folder, taxon_file):
 
     organism_dat = os.path.join(run_folder, 'organism-params.dat')
     genetic_dat = os.path.join(run_folder, 'genetic-elements.dat')
-    lisp_pathname = os.path.join(run_folder, 'dat_creation.lisp')
+    lisp_pathname = os.path.join(run_folder, 'flat_files_creation.lisp')
 
     fasta_extensions = ['.fasta', '.fsa']
 
@@ -527,7 +527,7 @@ def create_dats_and_lisp(run_folder, taxon_file):
                                 genetic_writer.writerow(['CODON-TABLE', codon_table])
                         genetic_writer.writerow(['//'])
     # Create the lisp script.
-    check_lisp_file = create_dat_creation_script(pgdb_id, lisp_pathname)
+    check_lisp_file = create_flat_creation_script(pgdb_id, lisp_pathname)
 
     return all([os.path.isfile(organism_dat), os.path.isfile(genetic_dat), check_lisp_file])
 
@@ -591,7 +591,7 @@ def pwt_input_files(run_folder, taxon_file):
         run_folder (str): path to the input folder
         taxon_file (str): path to the taxon_id.tsv file
     """
-    required_files = set(['organism-params.dat', 'genetic-elements.dat', 'dat_creation.lisp'])
+    required_files = set(['organism-params.dat', 'genetic-elements.dat', 'flat_files_creation.lisp'])
     files_in = set(next(os.walk(run_folder))[2])
 
     species_folder = os.path.basename(run_folder)
@@ -606,7 +606,7 @@ def pwt_input_files(run_folder, taxon_file):
         missing_string = 'no missing files'
     else:
         missing_string = 'missing {0}'.format('; '.join(required_files.difference(files_in))) + '. Inputs file created for {0}'.format(species_folder)
-        check_datas_lisp = create_dats_and_lisp(run_folder, taxon_file)
+        check_datas_lisp = create_flats_and_lisp(run_folder, taxon_file)
         if check_datas_lisp is None:
             logger.critical('Error with the creation of input files of {0}.'.format(run_folder))
             error_found = True
@@ -617,7 +617,7 @@ def pwt_input_files(run_folder, taxon_file):
     return error_found
 
 
-def create_only_dat_lisp(pgdbs_folder_path, tmp_folder):
+def create_only_flat_lisp(pgdbs_folder_path, tmp_folder):
     """
     Create a lisp script file for each PGDB in the ptools-local folder.
     Return a generator with the PGDB IDs.
@@ -635,8 +635,8 @@ def create_only_dat_lisp(pgdbs_folder_path, tmp_folder):
             pgdb_pathname = os.path.join(tmp_folder, pgdb_id)
             tmp_pgdb_path = os.path.join(tmp_folder, pgdb_id)
             os.mkdir(tmp_pgdb_path)
-            lisp_pathname = os.path.join(pgdb_pathname, 'dat_creation.lisp')
-            check_lisp_file = create_dat_creation_script(pgdb_id, lisp_pathname)
+            lisp_pathname = os.path.join(pgdb_pathname, 'flat_files_creation.lisp')
+            check_lisp_file = create_flat_creation_script(pgdb_id, lisp_pathname)
             if not check_lisp_file:
                 raise Exception('Error with the creation of the lisp script for {0}'.format(species_pgdb))
 

--- a/mpwt/pathologic_input.py
+++ b/mpwt/pathologic_input.py
@@ -4,7 +4,7 @@ Check input folders and input files.
 Create PathoLogic input files:
 -organism-params.dat
 -genetic-elements.dats
--dat_creation.lisp
+-flat_files_creation.lisp
 """
 
 import csv

--- a/mpwt/pwt_wrapper.py
+++ b/mpwt/pwt_wrapper.py
@@ -245,7 +245,7 @@ def run_pwt_dat(species_input_folder_path):
     return error_status
 
 
-def run_move_pgdb(pgdb_folder_dbname, pgdb_folder_path, dat_extraction, output_folder, size_reduction, xml_extraction, owl_extraction):
+def run_move_pgdb(pgdb_folder_dbname, pgdb_folder_path, dat_extraction, output_folder, size_reduction, xml_extraction, owl_extraction, col_extraction):
     """
     Move the result files inside the shared folder containing the input data.
     pgdb_folder_dbname: ID of the species.
@@ -259,6 +259,7 @@ def run_move_pgdb(pgdb_folder_dbname, pgdb_folder_path, dat_extraction, output_f
         size_reduction (bool): to compress or not the results
         xml_extraction (bool): to extract or not the metabolic-reactions.xml'
         owl_extraction (bool): to extract or not the owl files
+        col_extraction (bool): to extract or not the tabular files (.col files)
     """
     output_species = os.path.join(output_folder, pgdb_folder_dbname)
 
@@ -269,9 +270,14 @@ def run_move_pgdb(pgdb_folder_dbname, pgdb_folder_path, dat_extraction, output_f
         keep_extensions.append('.xml')
     if owl_extraction:
         keep_extensions.append('.owl')
+    if col_extraction:
+        keep_extensions.append('.col')
 
     if xml_extraction and len(keep_extensions) == 1:
         xml_file = os.path.join(*[pgdb_folder_path, '1.0', 'data', 'metabolic-reactions.xml'])
+        if not os.path.exists(xml_file):
+            logger.critical('Missing metabolic-reactions.xml for ' + pgdb_folder_dbname + '. To create it use mpwt --dat.')
+            return
         shutil.copyfile(xml_file, output_species+'.xml')
         if size_reduction:
             shutil.rmtree(pgdb_folder_path)
@@ -279,15 +285,24 @@ def run_move_pgdb(pgdb_folder_dbname, pgdb_folder_path, dat_extraction, output_f
 
     if owl_extraction and len(keep_extensions) == 1:
         owl_level_2 = os.path.join(*[pgdb_folder_path, '1.0', 'data', 'biopax-level2.owl'])
+        if not os.path.exists(owl_level_2):
+            logger.critical('Missing biopax-level2.owl for ' + pgdb_folder_dbname + '. To create it use mpwt --dat.')
+            return
         owl_level_3 = os.path.join(*[pgdb_folder_path, '1.0', 'data', 'biopax-level3.owl'])
+        if not os.path.exists(owl_level_3):
+            logger.critical('Missing biopax-level3.owl for ' + pgdb_folder_dbname + '. To create it use mpwt --dat.')
+            return
         shutil.copyfile(owl_level_2, output_species+'-level2.owl')
         shutil.copyfile(owl_level_3, output_species+'-level3.owl')
         if size_reduction:
             shutil.rmtree(pgdb_folder_path)
         return
 
-    if dat_extraction:
+    if len(keep_extensions) > 0:
         pgdb_tmp_folder_path = os.path.join(*[pgdb_folder_path, '1.0', 'data'])
+        if not os.path.exists(pgdb_tmp_folder_path):
+            logger.critical('Missing ' + pgdb_tmp_folder_path + ' folder.')
+            return
     else:
         pgdb_tmp_folder_path = pgdb_folder_path
 

--- a/mpwt/pwt_wrapper.py
+++ b/mpwt/pwt_wrapper.py
@@ -245,7 +245,7 @@ def run_pwt_dat(species_input_folder_path):
     return error_status
 
 
-def run_move_pgdb(pgdb_folder_dbname, pgdb_folder_path, dat_extraction, output_folder, size_reduction):
+def run_move_pgdb(pgdb_folder_dbname, pgdb_folder_path, dat_extraction, output_folder, size_reduction, xml_extraction):
     """
     Move the result files inside the shared folder containing the input data.
     pgdb_folder_dbname: ID of the species.
@@ -259,6 +259,13 @@ def run_move_pgdb(pgdb_folder_dbname, pgdb_folder_path, dat_extraction, output_f
         size_reduction (bool): to compress or not the results
     """
     output_species = os.path.join(output_folder, pgdb_folder_dbname)
+
+    if xml_extraction:
+        xml_file = os.path.join(*[pgdb_folder_path, '1.0', 'data', 'metabolic-reactions.xml'])
+        shutil.copyfile(xml_file, output_species+'.xml')
+        if size_reduction:
+            shutil.rmtree(pgdb_folder_path)
+        return
 
     if dat_extraction:
         pgdb_tmp_folder_path = os.path.join(*[pgdb_folder_path, '1.0', 'data'])

--- a/mpwt/pwt_wrapper.py
+++ b/mpwt/pwt_wrapper.py
@@ -314,9 +314,9 @@ def run_move_pgdb(pgdb_folder_dbname, pgdb_folder_path, dat_extraction, output_f
                 pgdb_file_pathname = os.path.join(pgdb_tmp_folder_path, pgdb_file)
                 pgdb_file_extension = os.path.splitext(pgdb_file)[1]
                 if pgdb_file_extension not in keep_extensions:
-                    if os.path.isfile(pgdb_file):
+                    if os.path.isfile(pgdb_file_pathname):
                         os.remove(pgdb_file_pathname)
-                    elif os.path.isdir(pgdb_file):
+                    elif os.path.isdir(pgdb_file_pathname):
                         shutil.rmtree(pgdb_file_pathname)
         zip_input_path = os.path.join(output_folder, pgdb_folder_dbname)
         shutil.make_archive(zip_input_path, 'zip', pgdb_tmp_folder_path)
@@ -326,10 +326,10 @@ def run_move_pgdb(pgdb_folder_dbname, pgdb_folder_path, dat_extraction, output_f
         shutil.copytree(pgdb_tmp_folder_path, output_species)
         if len(keep_extensions) > 0:
             for pgdb_file in os.listdir(output_species):
-                pgdb_path = os.path.join(output_species, pgdb_file)
+                pgdb_file_pathname = os.path.join(output_species, pgdb_file)
                 pgdb_file_extension = os.path.splitext(pgdb_file)[1]
                 if pgdb_file_extension not in keep_extensions:
-                    if os.path.isfile(pgdb_path):
-                        os.remove(pgdb_path)
-                    elif os.path.isdir(pgdb_path):
-                        shutil.rmtree(pgdb_path)
+                    if os.path.isfile(pgdb_file_pathname):
+                        os.remove(pgdb_file_pathname)
+                    elif os.path.isdir(pgdb_file_pathname):
+                        shutil.rmtree(pgdb_file_pathname)

--- a/mpwt/utils.py
+++ b/mpwt/utils.py
@@ -131,7 +131,7 @@ def cleaning(number_cpu=None, verbose=None):
 
 def cleaning_input(input_folder, verbose=None):
     """
-    Remove dat_creation.lisp, pathologic.log, genetic-elements.dat and organism-params.dat in a genbank folder.
+    Remove flat_files_creation.lisp, pathologic.log, genetic-elements.dat and organism-params.dat in a genbank folder.
 
     Args:
         input_folder (str): pathname to input folder
@@ -151,10 +151,10 @@ def cleaning_input(input_folder, verbose=None):
 
     for input_path in input_paths:
         if os.path.isdir(input_path):
-            lisp_script = os.path.join(input_path, 'dat_creation.lisp')
+            lisp_script = os.path.join(input_path, 'flat_files_creation.lisp')
             patho_log = os.path.join(input_path, 'pathologic.log')
             pwt_log = os.path.join(input_path, 'pwt_terminal.log')
-            dat_log = os.path.join(input_path, 'dat_creation.log')
+            flat_log = os.path.join(input_path, 'flat_files_creation.log')
             genetic_dat = os.path.join(input_path, 'genetic-elements.dat')
             organism_dat = os.path.join(input_path, 'organism-params.dat')
             if os.path.exists(lisp_script):
@@ -163,8 +163,8 @@ def cleaning_input(input_folder, verbose=None):
                 os.remove(patho_log)
             if os.path.exists(pwt_log):
                 os.remove(pwt_log)
-            if os.path.exists(dat_log):
-                os.remove(dat_log)
+            if os.path.exists(flat_log):
+                os.remove(flat_log)
             if os.path.exists(genetic_dat):
                 os.remove(genetic_dat)
             if os.path.exists(organism_dat):

--- a/mpwt_pipeline.svg
+++ b/mpwt_pipeline.svg
@@ -484,18 +484,18 @@
            x="85.724205">attribute-values flat files creation</tspan></tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="269.7999"
        y="201.98994"
        id="text1141"><tspan
          x="269.7999"
          y="201.98994"
          id="tspan1139"
-         style="fill:#339b00;fill-opacity:1;stroke:none;stroke-width:0.26458332"><tspan
+         style="fill:#339b00;fill-opacity:1;stroke:none;stroke-width:0.264583"><tspan
            x="269.7999"
            y="201.98994"
-           style="fill:#339b00;fill-opacity:1;stroke:none;stroke-width:0.26458332;stroke-opacity:1"
-           id="tspan1137">--dat</tspan></tspan></text>
+           style="fill:#339b00;fill-opacity:1;stroke:none;stroke-width:0.264583;stroke-opacity:1"
+           id="tspan1137">--flat</tspan></tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"

--- a/mpwt_pipeline.svg
+++ b/mpwt_pipeline.svg
@@ -390,7 +390,8 @@
            height="74.751289"
            x="-12.121831"
            y="39.636158" /></flowRegion><flowPara
-         id="flowPara4541">PathoLogic, GenbBank, GFF</flowPara></flowRoot>    <text
+         id="flowPara4541">PathoLogic, GenbBank, GFF</flowPara></flowRoot>
+    <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
        x="28.788073"
@@ -510,26 +511,26 @@
            id="tspan1281"
            style="stroke-width:0.26458332">output folder</tspan></tspan></text>
     <rect
-       style="fill:#241f1c;fill-opacity:0;stroke:#000000;stroke-width:1.3240217;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#241f1c;fill-opacity:0;stroke:#000000;stroke-width:1.32402;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21-8-0-1"
-       width="228.52412"
-       height="69.721649"
+       width="227.26556"
+       height="102.9367"
        x="437.93289"
        y="-136.99863" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="467.11868"
        y="-80.348541"
        id="text1279"><tspan
          x="467.11868"
          y="-80.348541"
          id="tspan1277"
-         style="stroke-width:0.26458332"><tspan
+         style="stroke-width:0.264583"><tspan
            x="467.11868"
            y="-80.348541"
            id="tspan1275"
-           style="stroke-width:0.26458332">attribute-values flat files only</tspan></tspan></text>
+           style="stroke-width:0.264583">attribute-values flat files</tspan></tspan></text>
     <rect
        style="fill:#241f1c;fill-opacity:0;stroke:#000000;stroke-width:1.41239357;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect21-8-9"
@@ -800,7 +801,8 @@
            height="47.594765"
            width="91.136284"
            id="rect1267" /></flowRegion><flowPara
-         id="flowPara1269" /></flowRoot>    <text
+         id="flowPara1269" /></flowRoot>
+    <text
        xml:space="preserve"
        style="font-style:normal;font-weight:normal;font-size:10.58333397px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
        x="614.69763"
@@ -913,8 +915,8 @@
        d="m 181.08322,54.37184 -0.33151,40.21241"
        id="path1849-8-8-2" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:3.00011039;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#Arrow2Send-8-1)"
-       d="m 382.95751,188.14454 175.68816,0.91946 1.56852,-250.449348"
+       style="fill:none;stroke:#000000;stroke-width:3.00011;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#Arrow2Send-8-1)"
+       d="m 382.95751,188.14454 175.68816,0.91946 1.56852,-213.818212"
        id="path1849-8-8-9" />
     <text
        xml:space="preserve"
@@ -936,6 +938,50 @@
          id="rect21-8-9-32"
          style="fill:#241f1c;fill-opacity:0;stroke:#003100;stroke-width:1.41239357;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="466.87836"
+       y="-68.737228"
+       id="text1279-7"><tspan
+         x="466.87836"
+         y="-68.737228"
+         id="tspan1277-0"
+         style="stroke-width:0.264583">metabolic-reactions.xml<tspan
+   x="466.87836"
+   y="-68.737228"
+   id="tspan1275-9"
+   style="stroke-width:0.264583" /></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="629.53802"
+       y="-69.0952"
+       id="text1141-4-7"><tspan
+         x="629.53802"
+         y="-69.0952"
+         id="tspan1139-6-9"
+         style="fill:#339b00;fill-opacity:1;stroke:none;stroke-width:0.264583">--mx</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="495.24017"
+       y="-57.299225"
+       id="text1279-7-3"><tspan
+         x="495.24017"
+         y="-57.299225"
+         id="tspan1277-0-7"
+         style="stroke-width:0.264583">biopax owl files</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="629.91394"
+       y="-57.95261"
+       id="text1141-4-7-9"><tspan
+         x="629.91394"
+         y="-57.95261"
+         id="tspan1139-6-9-2"
+         style="fill:#339b00;fill-opacity:1;stroke:none;stroke-width:0.264583">--mo</tspan></text>
   </g>
   <path
      id="path5037"

--- a/mpwt_pipeline.svg
+++ b/mpwt_pipeline.svg
@@ -982,6 +982,26 @@
          y="-57.95261"
          id="tspan1139-6-9-2"
          style="fill:#339b00;fill-opacity:1;stroke:none;stroke-width:0.264583">--mo</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="503.35449"
+       y="-46.200123"
+       id="text1279-7-3-3"><tspan
+         x="503.35449"
+         y="-46.200123"
+         id="tspan1277-0-7-6"
+         style="stroke-width:0.264583">tabular files</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="630.03375"
+       y="-47.695232"
+       id="text1141-4-7-9-3"><tspan
+         x="630.03375"
+         y="-47.695232"
+         id="tspan1139-6-9-2-6"
+         style="fill:#339b00;fill-opacity:1;stroke:none;stroke-width:0.264583">--mc</tspan></text>
   </g>
   <path
      id="path5037"

--- a/test/test_mpwt_functions.py
+++ b/test/test_mpwt_functions.py
@@ -12,11 +12,11 @@ import os
 
 def test_create_dats_and_lisp():
     input_path = os.path.join(*['test', 'fatty_acid_beta_oxydation_I'])
-    mpwt.pathologic_input.create_dats_and_lisp(input_path, False)
+    mpwt.pathologic_input.create_flats_and_lisp(input_path, False)
 
     genetic_pathname = os.path.join(*['test', 'fatty_acid_beta_oxydation_I', 'genetic-elements.dat'])
     organism_pathname = os.path.join(*['test', 'fatty_acid_beta_oxydation_I', 'organism-params.dat'])
-    lisp_pathname = os.path.join(*['test', 'fatty_acid_beta_oxydation_I' , 'dat_creation.lisp'])
+    lisp_pathname = os.path.join(*['test', 'fatty_acid_beta_oxydation_I' , 'flat_files_creation.lisp'])
 
     genetic_string_expected = 'NAME\t\nANNOT-FILE\tfatty_acid_beta_oxydation_I.gbk\n//\n'
     organism_string_expected = 'ID\tfatty_acid_beta_oxydation_I\nSTORAGE\tFILE\nNCBI-TAXON-ID\t511145\nNAME\tEscherichia coli str. K-12 substr. MG1655\n'
@@ -40,10 +40,10 @@ def test_create_dats_and_lisp():
 def test_check_input_and_existing_pgdb():
     mpwt.remove_pgdbs('fatty_acid_beta_oxydation_icyc,fatty_acid_beta_oxydation_i_gffcyc,fatty_acid_beta_oxydation_i_pfcyc')
 
-    run_patho_ids, run_dat_ids = mpwt.pathologic_input.check_input_and_existing_pgdb(['fatty_acid_beta_oxydation_I', 'fatty_acid_beta_oxydation_I_pf', 'fatty_acid_beta_oxydation_I_gff'], 'test', None, 1)
+    run_patho_ids, run_flat_ids = mpwt.pathologic_input.check_input_and_existing_pgdb(['fatty_acid_beta_oxydation_I', 'fatty_acid_beta_oxydation_I_pf', 'fatty_acid_beta_oxydation_I_gff'], 'test', None, 1)
     assert sorted(run_patho_ids) == sorted(['fatty_acid_beta_oxydation_I', 'fatty_acid_beta_oxydation_I_pf', 'fatty_acid_beta_oxydation_I_gff'])
-    assert not run_dat_ids
+    assert not run_flat_ids
 
-    run_patho_ids, run_dat_ids = mpwt.pathologic_input.check_input_and_existing_pgdb(['wrong.gbk.id.gbk'], 'test_wrong_id', None, 1)
+    run_patho_ids, run_flat_ids = mpwt.pathologic_input.check_input_and_existing_pgdb(['wrong.gbk.id.gbk'], 'test_wrong_id', None, 1)
     assert not run_patho_ids
-    assert not run_dat_ids
+    assert not run_flat_ids

--- a/test/test_mpwt_pathway_tools.py
+++ b/test/test_mpwt_pathway_tools.py
@@ -43,7 +43,7 @@ def test_multiprocess_pwt_import():
     mpwt.cleaning_input('test')
 
     mpwt.create_pathologic_file('test', 'test_pf')
-    mpwt.multiprocess_pwt('test_pf', 'test_output', patho_inference=True, dat_creation=True, dat_extraction=True, size_reduction=False, number_cpu=3, verbose=True)
+    mpwt.multiprocess_pwt('test_pf', 'test_output', patho_inference=True, flat_creation=True, dat_extraction=True, size_reduction=False, number_cpu=3, verbose=True)
 
     pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_I_gff', 'pathways.dat'])
     expected_tca_reactions = reaction_extraction(pathway_fabo_pathname)
@@ -71,7 +71,7 @@ def test_multiprocess_pwt_call():
     subprocess.call(['mpwt', '-f', 'test', '--clean'])
     subprocess.call(['mpwt', '-f', 'test', '--patho'])
 
-    subprocess.call(['mpwt', '-o', 'test_output', '--dat', '--md', '--mx', '--mc', '--mo', '--cpu', '3'])
+    subprocess.call(['mpwt', '-o', 'test_output', '--flat', '--md', '--mx', '--mc', '--mo', '--cpu', '3'])
 
     pgdbs = mpwt.list_pgdb()
     assert set(['fatty_acid_beta_oxydation_i_gffcyc', 'fatty_acid_beta_oxydation_i_pfcyc', 'fatty_acid_beta_oxydation_icyc']).issubset(set(pgdbs))

--- a/test/test_mpwt_pathway_tools.py
+++ b/test/test_mpwt_pathway_tools.py
@@ -71,23 +71,22 @@ def test_multiprocess_pwt_call():
     subprocess.call(['mpwt', '-f', 'test', '--clean'])
     subprocess.call(['mpwt', '-f', 'test', '--patho'])
 
-    subprocess.call(['mpwt', '-f', 'test', '-o', 'test_output', '--dat', '--md', '--cpu', '3'])
+    subprocess.call(['mpwt', '-o', 'test_output', '--dat', '--md', '--mx', '--mc', '--mo', '--cpu', '3'])
 
     pgdbs = mpwt.list_pgdb()
     assert set(['fatty_acid_beta_oxydation_i_gffcyc', 'fatty_acid_beta_oxydation_i_pfcyc', 'fatty_acid_beta_oxydation_icyc']).issubset(set(pgdbs))
 
-    pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_I_gff', 'pathways.dat'])
+    pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_i_gff', 'pathways.dat'])
     expected_tca_reactions = reaction_extraction(pathway_fabo_pathname)
     assert set(fabo_reactions()).issubset(set(expected_tca_reactions))
 
-    pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_I', 'pathways.dat'])
+    pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_i', 'pathways.dat'])
     expected_fabo_reactions = reaction_extraction(pathway_fabo_pathname)
     assert set(fabo_reactions()).issubset(set(expected_fabo_reactions))
 
-    pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_I_pf', 'pathways.dat'])
+    pathway_fabo_pathname = os.path.join(*['test_output', 'fatty_acid_beta_oxydation_i_pf', 'pathways.dat'])
     expected_pf_fabo_reactions = reaction_extraction(pathway_fabo_pathname)
     assert set(fabo_reactions()).issubset(set(expected_pf_fabo_reactions))
 
     subprocess.call(['mpwt', '-f', 'test', '--clean'])
     shutil.rmtree('test_output')
-


### PR DESCRIPTION
**Warning**:
In this version, some option names have been changed:
- "--dat" ("dat_creation" in python code) has been replaced by "--flat" ("flat_creation" in python code) to better reflect the attribute-values flat files created by this option.

Add:

- new options to extract other files to the ouput folder (issue #63):
    - "--mx" ("xml_creation") to extract XML files created by MetaFlux.
    - "--mo" ("owl_extraction") to extract owl files.
    - "--mc" ("col_extraction") to extract tabulated files ('.col' extension).

Fix:

- issue with '-r' (size_reduction) option: all files were extracted instead of only requested output files.

Modify:

- replace "--dat" ("dat_creation") by "--flat" ("flat_creation") to better reflect data created by this command.
- use PGDB ID as output name when using mpwt without input_folder (like "mpwt -o output_folder").
- update readme.
